### PR TITLE
Adds a -print option to let you pretty print an existing .json report to the console

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,21 +83,16 @@ func parseFlags() {
 	createBucketArg := flag.Bool("create-bucket", false, "create new bucket(default false)")
 	logPathArg := flag.String("log-path", "", "Specify the path of the log file. Default is 'currentDir'")
 	modeArg := flag.String("mode", "latency", "What do you want to measure? Choose 'latency' or 'burst'. Default is 'latency'")
-	fixJsonArg := flag.String("fix-json", "", "A path to search for .json reports to be parsed and fixed, so that they match the current version of storage-benchmark.")
+	fixArg := flag.Bool("fix", false, "If set all .json reports given with the -json option will be parsed and fixed, so that they match the current version of storage-benchmark.")
 	printArg := flag.Bool("print", false, "If set all .json reports given with -json option will be printed using the standard console output format.")
 
 	// parse the arguments and set all the global variables accordingly
 	flag.Parse()
 
 	showVersion = *versionArg
-	if *fixJsonArg != "" {
-		jsonPath = *fixJsonArg
-		fix = true
-	}
-	if *jsonArg != "" {
-		jsonPath = *jsonArg
-	}
+	fix = *fixArg
 	print = *printArg
+	jsonPath = *jsonArg
 
 	// Stop parsing flags if -version or -fix-json arguments are there
 	if showVersion || fix || print {

--- a/sbmark/benchmark.go
+++ b/sbmark/benchmark.go
@@ -161,6 +161,17 @@ func (ctx *BenchmarkContext) NumberOfThreads() int {
 	return ctx.ThreadsMax - ctx.ThreadsMin + 1
 }
 
+func (ctx *BenchmarkContext) PrintSettings() {
+	fmt.Print("\n--- storage-benchmark - Settings ------------------------------------------------------------------------------------------------------------------------------\n\n")
+	fmt.Printf(`Date:			%s`+"\n"+
+		`Description:	%s`+"\n"+
+		`Client:		%s`+"\n"+
+		`Server:		%s`+"\n"+
+		`Mode:			%s`+"\n"+
+		`Samples:		%d`+"\n",
+		ctx.Report.DateTimeUTC, ctx.Description, ctx.Report.ClientEnv, ctx.Report.ServerEnv, ctx.ModeName, ctx.Samples)
+}
+
 // formats bytes to KB or MB
 func ByteFormat(bytes float64) string {
 	if bytes >= 1024*1024 {

--- a/sbmark/mode-burst.go
+++ b/sbmark/mode-burst.go
@@ -22,7 +22,7 @@ func (m *BurstBenchmarkMode) IsFinished(numberOfRuns int) bool {
 }
 
 func (m *BurstBenchmarkMode) PrintHeader(operationToTest string) {
-	fmt.Print("\n--- BENCHMARK - Burst ---------------------------------------------------------------------------------------------------------\n\n")
+	fmt.Print("\n--- BENCHMARK - Burst -----------------------------------------------------------------------------------------------------------------------------------------\n\n")
 
 	// prints the table header for the test results
 	fmt.Printf("Max throughput for operation '%s' \n", operationToTest)

--- a/sbmark/mode-latency.go
+++ b/sbmark/mode-latency.go
@@ -22,7 +22,7 @@ func (m *LatencyBenchmarkMode) IsFinished(numberOfRuns int) bool {
 }
 
 func (m *LatencyBenchmarkMode) PrintHeader(operationToTest string) {
-	fmt.Print("\n--- BENCHMARK - Latency ------------------------------------------------------------------------------------------------------\n\n")
+	fmt.Print("\n--- BENCHMARK - Latency ---------------------------------------------------------------------------------------------------------------------------------------\n\n")
 
 	fmt.Printf("Latency Distribution Example (values are hard coded and only for explanation)\n\n")
 	fmt.Printf(``+


### PR DESCRIPTION
The second commit changes the existing -fix-json to correspond to the -print option.
storage-benchmark -print -json path/to/report.json
storage-benchmark -fix -json path/to/report.json
storage-benchmark -print -fix -json path/to/report.json