### PR TITLE
Add -keepalive option to enable or disable connection pooling

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func parseFlags() {
 	logPathArg := flag.String("log-path", "", "Specify the path of the log file. Default is 'currentDir'")
 	modeArg := flag.String("mode", "latency", "What do you want to measure? Choose 'latency' or 'burst'. Default is 'latency'")
 	fixJsonArg := flag.String("fix-json", "", "A path to search for .json reports to be parsed and fixed, so that they match the current version of storage-benchmark.")
+	keepAliveArg := flag.String("keepalive", "mode", "Use 'enabled' or 'disabled' to explicitly enable or dissable connection pooling to your endpoint. Use 'mode' to use the default of the specified benchmark mode. Default is 'mode'.")
 
 	// parse the arguments and set all the global variables accordingly
 	flag.Parse()
@@ -119,6 +120,7 @@ func parseFlags() {
 		InfoLogger:    createLogger("INFO "),
 		WarningLogger: createLogger("WARNING "),
 		ErrorLogger:   createLogger("ERROR "),
+		KeepAlive:     *keepAliveArg,
 	}
 
 	err := ctx.Start()

--- a/sbmark/benchmark.go
+++ b/sbmark/benchmark.go
@@ -83,6 +83,9 @@ type BenchmarkContext struct {
 	InfoLogger    *log2.Logger `json:"-"`
 	WarningLogger *log2.Logger `json:"-"`
 	ErrorLogger   *log2.Logger `json:"-"`
+
+	// Whether a connection pooling should be 'enabled' or 'disabled'. If not specified or set to 'mode' the default value of the BenchmarkMode is used.
+	KeepAlive string `json:"-"`
 }
 
 func (ctx *BenchmarkContext) Start() error {
@@ -107,8 +110,19 @@ func (ctx *BenchmarkContext) setupClient() {
 			Region:            ctx.Region,
 			Endpoint:          ctx.Endpoint,
 			Insecure:          true,
-			DisableKeepAlives: ctx.Mode.DisableKeepAlives(),
+			DisableKeepAlives: ctx.disableKeepAlives(),
 		})
+	}
+}
+
+func (ctx *BenchmarkContext) disableKeepAlives() bool {
+	switch strings.ToLower(ctx.KeepAlive) {
+	case "enabled":
+		return false
+	case "disabled":
+		return true
+	default:
+		return ctx.Mode.DisableKeepAlives()
 	}
 }
 


### PR DESCRIPTION
Every BenchmarkMode has a default how to deal with connection pooling. In mode "latency" the connection pooling is disabled, why the DisableKeepAlives() function returns true.
The mode "burst" returns false, to enable connection pooling.

With this commit the user can explicitly enable or disable the connection pooling by specifying the -keepalive cli option.

Usage:
storage-benchmark -keepalive enabled
storage-benchmark -keepalive disabled

If -keepalive is not set the selected BenchmarkMode (-mode) decides.